### PR TITLE
Fixed parent to fetch parent id and added depth property

### DIFF
--- a/src/ts/network/routers/structure.ts
+++ b/src/ts/network/routers/structure.ts
@@ -16,7 +16,8 @@ router.addRoute({
           id: folder.id,
           name: folder.name,
           type: folder.type,
-          parent: folder.parent?.id,
+          parent: (folder as any)._source?.folder ?? "root",
+          depth: folder.depth,
           path: folder.uuid,
           sorting: (folder as any).sort,
           sortingMode: (folder as any).sortingMode


### PR DESCRIPTION
The parent seems to only exist as id but that would be still enough to build a tree of folders. Also the depth property was added as it can help. Instead of an empty parent property the root folder is given a "root id". This allows to filter all root folders (even though it also would work with a folder depth of 1)